### PR TITLE
fix: create reminder functionality

### DIFF
--- a/utils/reminders.ts
+++ b/utils/reminders.ts
@@ -233,9 +233,10 @@ async function createReminder(
         reminderProps.dueDate = new Date(dueDate);
       }
 
-      // Create the reminder
-      const newReminder = list.make({
+      // Create the reminder at the specified list
+      const newReminder = Reminders.make({
         new: "reminder",
+        at: list,
         withProperties: reminderProps,
       });
 


### PR DESCRIPTION
# Issue Fix

## Recommended Solution

### Fix Strategy
Replace the incorrect `list.make()` call with `Reminders.make()` using the `at` parameter to properly associate the reminder with the specified list.

### Implementation Steps
1. **File**: `utils/reminders.ts`
   - Change: Replace lines 237-240 with the corrected code
   - Reason: This properly associates the reminder with the target list using JXA's `at` parameter

### Why This Works
The JXA `make` method accepts an `at` parameter that specifies the container for the new object. When creating a reminder, we need to tell the Reminders application to create the reminder at the specific list, not create it as a child of the list object.

Current incorrect code:
```javascript
const newReminder = list.make({
  new: "reminder",
  withProperties: reminderProps,
});
```

Fixed code:
```javascript
const newReminder = Reminders.make({
  new: "reminder",
  at: list,
  withProperties: reminderProps,
});
```